### PR TITLE
add: support for useQuery based GET request handling

### DIFF
--- a/apps/client-web/src/features/auth/hooks/useRefreshAccessToken.ts
+++ b/apps/client-web/src/features/auth/hooks/useRefreshAccessToken.ts
@@ -1,20 +1,30 @@
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
-import { useApiMutation } from "@client-web/hooks/useApiMutation";
+import { useApiQuery } from "@client-web/hooks/useApiQuery";
 import { useAuthStore } from "@client-web/store/auth";
 import authService from "@client-web/features/auth/services";
 
 export const useRefreshAccessToken = () => {
   const { setAuth, clearAuth } = useAuthStore();
   const router = useRouter();
-  return useApiMutation({
-    mutationFn: authService.refreshAccessToken,
-    onSuccess: (data) => {
-      setAuth(data.data.token);
-    },
-    onError: () => {
+  const query = useApiQuery({
+    queryKey: ["refresh-access-token"],
+    queryFn: authService.refreshAccessToken,
+  });
+
+  useEffect(() => {
+    if (query.isSuccess && query.data) {
+      setAuth(query.data.data.token);
+    }
+  }, [query.isSuccess, query.data, setAuth]);
+
+  useEffect(() => {
+    if (query.isError) {
       clearAuth();
       router.push("/signin");
-    },
-  });
+    }
+  }, [query.isError, clearAuth, router]);
+
+  return query;
 };

--- a/apps/client-web/src/features/auth/hooks/useSignOut.ts
+++ b/apps/client-web/src/features/auth/hooks/useSignOut.ts
@@ -1,18 +1,25 @@
 import { useRouter } from "next/navigation";
 
-import { useApiMutation } from "@client-web/hooks/useApiMutation";
+import { useApiQuery } from "@client-web/hooks/useApiQuery";
 import authService from "@client-web/features/auth/services";
 import { useAuthStore } from "@client-web/store/auth";
+import { useEffect } from "react";
 
 export const useSignOut = () => {
   const clearAuth = useAuthStore((state) => state.clearAuth);
   const router = useRouter();
 
-  return useApiMutation({
-    mutationFn: authService.signOut,
-    onSuccess: () => {
+  const query = useApiQuery({
+    queryKey: ["sign-out"],
+    queryFn: authService.signOut,
+  });
+
+  useEffect(() => {
+    if (query.isSuccess && query.data) {
       clearAuth();
       router.push("/signin");
-    },
-  });
+    }
+  }, [query.isSuccess, query.data, clearAuth, router]);
+
+  return query;
 };

--- a/apps/client-web/src/hooks/useApiQuery.ts
+++ b/apps/client-web/src/hooks/useApiQuery.ts
@@ -1,0 +1,17 @@
+import {
+  useQuery,
+  type UseQueryOptions,
+  type QueryClient,
+} from "@tanstack/react-query";
+
+import type {
+  T_ApiSuccessResponse,
+  T_ApiErrorResponse,
+} from "@client-web/services/config/api";
+
+export function useApiQuery<T_Data>(
+  options: UseQueryOptions<T_ApiSuccessResponse<T_Data>, T_ApiErrorResponse>,
+  queryClient?: QueryClient,
+) {
+  return useQuery(options, queryClient);
+}

--- a/apps/client-web/src/services/config/api.ts
+++ b/apps/client-web/src/services/config/api.ts
@@ -10,7 +10,6 @@ export type T_ApiSuccessResponse<T> = {
 };
 
 export type T_ApiErrorResponse = {
-  success: false;
   type: string;
   title: string;
   status: number;


### PR DESCRIPTION
`useQuery` usage is abstracted away with a typed wrapper `useApiQuery` to provide better response type inference. Reference implementations with `useSignOut` and `useRefreshAccessToken` hooks have also been included